### PR TITLE
Fixed a regression with identifying the target if the browser doesn't…

### DIFF
--- a/src/inputjs/compute-input-data.js
+++ b/src/inputjs/compute-input-data.js
@@ -71,7 +71,7 @@ export default function computeInputData(manager, input) {
   } else if (srcEvent.path) {
     srcEventTarget = srcEvent.path[0];
   } else {
-    srcEventTarget = target;
+    srcEventTarget = srcEvent.target;
   }
 
   if (hasParent(srcEventTarget, target)) {


### PR DESCRIPTION
… support composedPath or path.

This is a regression introduced with https://github.com/naver/hammer.js/pull/22 and https://github.com/naver/hammer.js/issues/21. The original code before the PR would use srcEvent.target:

```
// find the correct target
let target = manager.element;
if (hasParent(input.srcEvent.target, target)) {
  target = input.srcEvent.target;
}
input.target = target;
```

After the PR it was using target directly:
```
...
} else {
    srcEventTarget = target;
  }
```
This causes an issue on browsers that fall into the final else block like IE and Edge. This PR restores the original functionality of using `srcEvent.target`:
```
...
} else {
    srcEventTarget = srcEvent.target;
  }
```