### PR TITLE
fix: failing test due to missing default value

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@egjs/hammerjs",
-  "version": "2.0.15-snapshot",
+  "version": "2.0.16-snapshot",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2909,6 +2909,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+      "dev": true
+    },
+    "filesize": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/filesize/-/filesize-3.6.1.tgz",
+      "integrity": "sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==",
       "dev": true
     },
     "fill-range": {
@@ -6284,6 +6290,15 @@
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
+    },
+    "print-sizes": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/print-sizes/-/print-sizes-0.1.0.tgz",
+      "integrity": "sha512-W5f2LCf5LzuxCdmW0or7zkeR2IZ1TJAAyYyn/hbS+bpIN1BfcNHPKX4V1jgFwp+5KXaYJEEo7vFrOqbMn7X+YA==",
+      "dev": true,
+      "requires": {
+        "filesize": "^3.6.1"
+      }
     },
     "private": {
       "version": "0.1.8",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
 		"jshint-stylish": "^2.2.0",
 		"lodash-compat": "^3.10.2",
 		"node-qunit-phantomjs": "^1.4.0",
+		"print-sizes": "^0.1.0",
 		"qunitjs": "^2.0.0",
 		"rollup": "^0.66.0",
 		"rollup-plugin-analyzer": "^2.1.0",
@@ -50,7 +51,8 @@
 		"node": ">=0.8.0"
 	},
 	"scripts": {
-		"build": "npm run rollup && npm run test:node",
+		"build": "npm run rollup && npm run test:node && npm run printsizes",
+		"printsizes": "print-sizes ./dist --exclude=\\.map",
 		"testbuild": "rollup -c ./testrollup.config.js",
 		"bannerize": "bannerize hammer.js hammer.min.js",
 		"connect": "serve -p 8000 ./",

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,4 +1,11 @@
 import { TOUCH_ACTION_COMPUTE } from "./touchactionjs/touchaction-Consts";
+import TapRecognizer from "./recognizers/tap";
+import PanRecognizer from "./recognizers/pan";
+import SwipeRecognizer from "./recognizers/swipe";
+import PinchRecognizer from "./recognizers/pinch";
+import RotateRecognizer from "./recognizers/rotate";
+import PressRecognizer from "./recognizers/press";
+import {DIRECTION_HORIZONTAL} from "./inputjs/input-consts";
 
 export default {
 	/**
@@ -43,14 +50,6 @@ export default {
 	 * @default null
 	 */
 	inputClass: null,
-
-	/**
-	 * @private
-	 * Default recognizer setup when calling `Hammer()`
-	 * When creating a new Manager these will be skipped.
-	 * @type {Array}
-	 */
-	preset: [],
 
 	/**
 	 * @private
@@ -111,3 +110,19 @@ export default {
 		tapHighlightColor: "rgba(0,0,0,0)",
 	},
 };
+
+/**
+ * @private
+ * Default recognizer setup when calling `Hammer()`
+ * When creating a new Manager these will be skipped.
+ * @type {Array}
+ */
+export const preset = [
+  [RotateRecognizer, { enable: false }],
+  [PinchRecognizer, { enable: false }, ['rotate']],
+  [SwipeRecognizer, { direction: DIRECTION_HORIZONTAL }],
+  [PanRecognizer, { direction: DIRECTION_HORIZONTAL }, ['swipe']],
+  [TapRecognizer],
+  [TapRecognizer, { event: 'doubletap', taps: 2 }, ['tap']],
+  [PressRecognizer]
+];

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -115,6 +115,7 @@ export default {
  * @private
  * Default recognizer setup when calling `Hammer()`
  * When creating a new Manager these will be skipped.
+ * This is separated with other defaults because of tree-shaking.
  * @type {Array}
  */
 export const preset = [

--- a/src/hammer.js
+++ b/src/hammer.js
@@ -1,5 +1,5 @@
 import Manager from "./manager";
-import defaults from "./defaults";
+import defaults, { preset } from "./defaults";
 import assign from './utils/assign';
 import {
   INPUT_START,
@@ -88,7 +88,7 @@ export default class Hammer {
 	static STATE_ENDED = STATE_ENDED;
 	static STATE_RECOGNIZED = STATE_RECOGNIZED;
 	static STATE_CANCELLED = STATE_CANCELLED;
-	static STATE_FAILED = STATE_FAILED; 
+	static STATE_FAILED = STATE_FAILED;
 	static Manager = Manager;
 	static Input = Input;
 	static TouchAction = TouchAction;
@@ -123,18 +123,12 @@ export default class Hammer {
 	static hasParent = hasParent;
 	static addEventListeners = addEventListeners;
 	static removeEventListeners = removeEventListeners;
-	static defaults = defaults;
+	static defaults = assign({}, defaults, { preset });
 	constructor(element, options = {}) {
 		return new Manager(element, {
 			recognizers: [
-					// RecognizerClass, options, [recognizeWith, ...], [requireFailure, ...]
-					[RotateRecognizer, { enable: false }],
-					[PinchRecognizer, { enable: false }, ['rotate']],
-					[SwipeRecognizer, { direction: DIRECTION_HORIZONTAL }],
-					[PanRecognizer, { direction: DIRECTION_HORIZONTAL }, ['swipe']],
-					[TapRecognizer],
-					[TapRecognizer, { event: 'doubletap', taps: 2 }, ['tap']],
-					[PressRecognizer]
+        // RecognizerClass, options, [recognizeWith, ...], [requireFailure, ...]
+        ...preset
 			],
 			...options,
 		});

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 
 import Hammer from "./hammer";
 import assign from "./utils/assign";
-import defaults from "./defaults";
+import defaults, { preset } from "./defaults";
 
 import {
   INPUT_START,
@@ -59,6 +59,8 @@ import splitStr from "./utils/split-str";
 import inArray from "./utils/in-array";
 import boolOrFn from "./utils/bool-or-fn";
 import hasParent from "./utils/has-parent";
+
+const mergedDefaults = assign({}, defaults, { preset })
 
 // this prevents errors when Hammer is loaded in the presence of an AMD
 //  style loader but by script tag, not by the loader.
@@ -118,5 +120,5 @@ export {
   hasParent,
   addEventListeners,
   removeEventListeners,
-  defaults,
+  mergedDefaults as defaults,
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 
 import Hammer from "./hammer";
 import assign from "./utils/assign";
-import defaults, { preset } from "./defaults";
 
 import {
   INPUT_START,
@@ -60,10 +59,10 @@ import inArray from "./utils/in-array";
 import boolOrFn from "./utils/bool-or-fn";
 import hasParent from "./utils/has-parent";
 
-const mergedDefaults = assign({}, defaults, { preset })
-
 // this prevents errors when Hammer is loaded in the presence of an AMD
 //  style loader but by script tag, not by the loader.
+
+const defaults = Hammer.defaults;
 
 export {
   Hammer as default,
@@ -120,5 +119,5 @@ export {
   hasParent,
   addEventListeners,
   removeEventListeners,
-  mergedDefaults as defaults,
+  defaults,
 };


### PR DESCRIPTION
This fixes the failing test due to missing preset value in `defaults` file.
I don't know why this value is missing, but it definitely looks like that is needed.