### PR TITLE
Bump types version

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,6 @@
 	"main": "dist/hammer.js",
 	"types": "src/hammer.d.ts",
 	"dependencies": {
-		"@types/hammerjs": "^2.0.36"
+		"@types/hammerjs": "^2.0.38"
 	}
 }


### PR DESCRIPTION
Bumping TS types to include changes in the TS repo:
- [[hammerjs] Add missing event data](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50438)
- [[hammerjs] Use number literals in constants](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50433)

Unmerged PRs: [[hammerjs] Use literal types for `eventType`](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50966)

I upgraded locally and the node still uses .36 version though the caret pin should be compatible with it, not sure why.